### PR TITLE
Fixes to the tg68k. Fixes #67 glitch in Nexus7, etc.

### DIFF
--- a/rtl/tg68k/TG68KdotC_Kernel.vhd
+++ b/rtl/tg68k/TG68KdotC_Kernel.vhd
@@ -530,12 +530,12 @@ begin
 	  rf_dest_addr <= brief(15 downto 12);
 	elsif set(get_bfoffset) = '1' then
 	  if opcode(15 downto 12) = "1110" then
-            rf_dest_addr <= '0' & sndOPC(8 downto 6);
+		rf_dest_addr <= '0' & sndOPC(8 downto 6);
 	  else
-	    rf_dest_addr <= sndOPC(9 downto 6);
+		rf_dest_addr <= sndOPC(9 downto 6);
 	  end if;
 	elsif dest_2ndHbits = '1' then
-	   rf_dest_addr <= '0' & sndOPC(14 downto 12);
+	  rf_dest_addr <= '0' & sndOPC(14 downto 12);
 	elsif set(write_reminder) = '1' then
 	  rf_dest_addr <= '0' & sndOPC(2 downto 0);
 	elsif setstackaddr = '1' then

--- a/rtl/tg68k/TG68KdotC_Kernel.vhd
+++ b/rtl/tg68k/TG68KdotC_Kernel.vhd
@@ -563,7 +563,7 @@ begin
 		rf_source_addr <= movem_regaddr;
 	  end if;
 	elsif source_2ndLbits = '1' then
-	  rf_dest_addr <= '0' & sndOPC(2 downto 0);
+	  rf_source_addr <= '0' & sndOPC(2 downto 0);
 	elsif source_2ndHbits = '1' then
 	  rf_source_addr <= '0' & sndOPC(14 downto 12);
 	elsif source_lowbits = '1' then

--- a/rtl/tg68k/TG68KdotC_Kernel.vhd
+++ b/rtl/tg68k/TG68KdotC_Kernel.vhd
@@ -529,11 +529,15 @@ begin
 	elsif set(briefext) = '1' then
 	  rf_dest_addr <= brief(15 downto 12);
 	elsif set(get_bfoffset) = '1' then
-	  rf_dest_addr <= sndOPC(9 downto 6);
+	  if opcode(15 downto 12) = "1110" then
+            rf_dest_addr <= '0' & sndOPC(8 downto 6);
+	  else
+	    rf_dest_addr <= sndOPC(9 downto 6);
+	  end if;
 	elsif dest_2ndHbits = '1' then
-	  rf_dest_addr <= sndOPC(15 downto 12);
+	   rf_dest_addr <= '0' & sndOPC(14 downto 12);
 	elsif set(write_reminder) = '1' then
-	  rf_dest_addr <= sndOPC(3 downto 0);
+	  rf_dest_addr <= '0' & sndOPC(2 downto 0);
 	elsif setstackaddr = '1' then
 	  rf_dest_addr <= "1111";
 	elsif dest_hbits = '1' then
@@ -559,9 +563,9 @@ begin
 		rf_source_addr <= movem_regaddr;
 	  end if;
 	elsif source_2ndLbits = '1' then
-	  rf_source_addr <= sndOPC(3 downto 0);
+	  rf_dest_addr <= '0' & sndOPC(2 downto 0);
 	elsif source_2ndHbits = '1' then
-	  rf_source_addr <= sndOPC(15 downto 12);
+	  rf_source_addr <= '0' & sndOPC(14 downto 12);
 	elsif source_lowbits = '1' then
 	  rf_source_addr <= source_areg & opcode(2 downto 0);
 	elsif exec(linksp) = '1' then


### PR DESCRIPTION
This was picked up by Toni Wilen's cputester.
Source/Destination register bits suffered from some confusion when an instructions that could only work with Data registers and had a bit set for address register. The result of this confusion was manifesting itself as wrong results or even writing the results into Address registers rather than Data registers.